### PR TITLE
fix broken links to testgrid dashboard

### DIFF
--- a/_posts/2018-08-12-update.md
+++ b/_posts/2018-08-12-update.md
@@ -37,7 +37,7 @@ The [Github Management Team](https://github.com/kubernetes/community/blob/master
 
 **Next Deadline: 1.12.0-beta0, August 14th**
 
-CI Signal needs to be green for Beta; please make sure your [blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and [upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) are passing.
+CI Signal needs to be green for Beta; please make sure your [blocking](https://testgrid.k8s.io/sig-release-master-blocking) and [upgrade tests](https://k8s-testgrid.appspot.com/sig-release-master-upgrade) are passing.
 
 The 1.12 cycle is halfway through, which means development is 2/3 done; Code Freeze is in 22 days.  The Release Team is validating a new build/push mechanism with a feature branch for 1.12, created for the beta.  This branch will aregularly fast-forward from master.
 

--- a/_posts/2018-08-19-update.md
+++ b/_posts/2018-08-19-update.md
@@ -71,4 +71,4 @@ Heapster is deprecated in 1.12, and will be removed entirely in 1.13.  Time to m
 
 ![graph of running PR flakiness](/2018/images/pr_flakiness.png)
 
-Crickenberger went over several boards and graphs that allow contributors to track flaky tests, including the above [bigquery chart of PR flakiness](https://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1).  Together with the [presubmits test grid](https://k8s-testgrid.appspot.com/presubmits-kubernetes-blocking#Summary), PR authors and code owners should regularly check if their code is making the builds or tests unreliable.
+Crickenberger went over several boards and graphs that allow contributors to track flaky tests, including the above [bigquery chart of PR flakiness](https://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1).  Together with the [presubmits test grid](https://testgrid.k8s.io/presubmits-kubernetes-blocking#Summary), PR authors and code owners should regularly check if their code is making the builds or tests unreliable.

--- a/_posts/2018-08-26-update.md
+++ b/_posts/2018-08-26-update.md
@@ -23,7 +23,7 @@ Steering Committee elections have started, and nominations are open until Sept. 
 
 **Next Deadline: Code Slush, August 28th**
 
-That's right, Code Slush [starts this week]().  It's time to clean up and finalize your PRs, and if that feature you're working on isn't stable yet, punt it to 1.13.  Code Freeze starts a week later. CI Signal is [not looking good](https://k8s-testgrid.appspot.com/sig-release-master-blocking), so we need everyone focused on fixing bugs.
+That's right, Code Slush [starts this week]().  It's time to clean up and finalize your PRs, and if that feature you're working on isn't stable yet, punt it to 1.13.  Code Freeze starts a week later. CI Signal is [not looking good](https://testgrid.k8s.io/sig-release-master-blocking), so we need everyone focused on fixing bugs.
 
 In order to simplify contributions, Release Lead Tim Pepper has proposed [to remove several required labels](https://groups.google.com/d/topic/kubernetes-dev/MjyJzhBEgkM/discussion), most notably `status/approved-for-milestone`, from PRs and issues during Code Freeze.  This would reduce the number of required labels to four (sig/, kind/, milestone, and priority/critical-urgent) from seven for 1.11.  This proposal should pass by lazy consensus Aug. 27th.
 

--- a/_posts/2022-11-20-update.md
+++ b/_posts/2022-11-20-update.md
@@ -17,7 +17,7 @@ Etcd has [announced some new data consistency bugs](https://groups.google.com/a/
 
 Just a few more things to finish off before 1.26 goes out, mostly the documentation and the feature blog.
 
-[CI signal is OK](https://github.com/orgs/kubernetes/projects/68/) but not great, with no tests failing (but some flaking) on [master-blocking](https://k8s-testgrid.appspot.com/sig-release-master-blocking) and a few failing on master-informing, particularly [cgroupv1-conformance](https://github.com/kubernetes/kubernetes/issues/113767).  If this is something you can help with, please jump in.  In general, please treat any failing test issues in your notifications as *extremely urgent* until 1.26 is released.
+[CI signal is OK](https://github.com/orgs/kubernetes/projects/68/) but not great, with no tests failing (but some flaking) on [master-blocking](https://testgrid.k8s.io/sig-release-master-blocking) and a few failing on master-informing, particularly [cgroupv1-conformance](https://github.com/kubernetes/kubernetes/issues/113767).  If this is something you can help with, please jump in.  In general, please treat any failing test issues in your notifications as *extremely urgent* until 1.26 is released.
 
 ## Merges
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixes a bunch of broken links to testgrid dashboard.

**Which issue(s) this PR fixes:**
This is related to an umbrella issue and fixes a task of the same:
https://github.com/kubernetes/test-infra/issues/30370