### PR TITLE
Added KEP of the week for 10/01 issue

### DIFF
--- a/_posts/2023-08-13-update.md
+++ b/_posts/2023-08-13-update.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Week Ending August 13, 2023
-date: 2023-08-14 22:00:00 -0000
+date: 2023-08-15 22:00:00 -0000
 slug: 2023-08-13-update
 ---
 
@@ -15,7 +15,7 @@ Nominations are open for the [Kubernetes Steering Committee election](https://gi
 
 **Next Deadline: 1.28 Released, August 15**
 
-We are still on schedule to release 1.28 this week.  But, that means that if any issue around this release is assigned to you, you need to respond immediately.
+We are still on schedule to release 1.28 this week.  Tuesday, even!  Pending last-minute delays.
 
 Patch releases have been [delayed until August 23rd](https://groups.google.com/a/kubernetes.io/g/dev/c/0ku-CI--1vc) due to conflicts with the 1.28 release schedule.
 
@@ -26,7 +26,6 @@ Patch releases have been [delayed until August 23rd](https://groups.google.com/a
 This KEP extends the Jobs API to support indexes for jobs, where the backoff limit is per index. The job can continue executing even if some of its indexes are failing. Currently, the indexes of an indexed job share a common backoff limit. When the job reaches this common backoff limit, the job is marked as failed by the job controller even if there are indexes which are yet to run to completion. The current implementation is not efficient if the indexes are truly independent of each other. If one index fails, the entire job would be marked as failed.
 
 The proposed solution involves adding a new policy where the backoff limit controls the number of retries per index of the job. All indexes of the job execute until they succeed or fail. A new API field to control the number of failed indexes is also proposed. This KEP was authored by [Michał Woźniak](https://github.com/mimowo) and [jensentanlo](https://github.com/jensentanlo) and is in alpha in v1.28
-
 
 ## Other Merges
 

--- a/_posts/2023-08-13-update.md
+++ b/_posts/2023-08-13-update.md
@@ -21,6 +21,12 @@ Patch releases have been [delayed until August 23rd](https://groups.google.com/a
 
 ## KEP of the Week
 
+[KEP 3850 - Backoff Limits Per Index For Indexed Jobs](https://features.k8s.io/3850)
+
+This KEP extends the Jobs API to support indexes for jobs, where the backoff limit is per index. The job can continue executing even if some of its indexes are failing. Currently, the indexes of an indexed job share a common backoff limit. When the job reaches this common backoff limit, the job is marked as failed by the job controller even if there are indexes which are yet to run to completion. The current implementation is not efficient if the indexes are truly independent of each other. If one index fails, the entire job would be marked as failed.
+
+The proposed solution involves adding a new policy where the backoff limit controls the number of retries per index of the job. All indexes of the job execute until they succeed or fail. A new API field to control the number of failed indexes is also proposed. This KEP was authored by [Michał Woźniak](https://github.com/mimowo) and [jensentanlo](https://github.com/jensentanlo) and is in alpha in v1.28
+
 
 ## Other Merges
 

--- a/_posts/2023-08-20-update.md
+++ b/_posts/2023-08-20-update.md
@@ -29,11 +29,9 @@ Patch releases for all supported versions are expected out on the 23rd, includin
 
 [KEP-3895: Interactive(-i) flag to kubectl delete for user confirmation](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3895-kubectl-delete-interactivity)
 
-This KEP adds an interactive mode for `kubectl delete` command, which provides users an option to confirm whether or not to delete the resources mentioned. Due to backwards compatibility reasons, directly asking the user for confirmation before deleting is not possible. Hence a new interactive flag (-i) is introduced, which when used would prompt the user to confirm if they really want to delete the resources selected.
+Adds an interactive mode for `kubectl delete` command, which provides users an option to confirm whether or not to delete the resources mentioned. For backwards compatibility, asking the user for confirmation before deleting by default is not possible. Hence the new interactive flag (-i), which when used prompts the user to confirm if they really want to delete the resources selected.
 
-When using the proposed interactive flag with `kubectl delete`, the user would be shown the list of resources that would be deleted. The command continues execution if the user confirms by entering `y`. If the user enters `n` or any other character, the command stops execution and returns a message with zero exit code.
-
-This KEP is in alpha in v1.28, and would be hidden behind a `KUBECTL_INTERACTIVE_DELETE` environment variable. The interactive flag can only be used if `KUBECTL_INTERACTIVE_DELETE=true` is exported.
+When using the proposed interactive flag with `kubectl delete`, the user will be shown the list of resources that would be deleted. The command continues execution if the user confirms by entering `y`. If the user enters `n` or any other character, the command stops execution and returns a message with zero exit code. This KEP is in alpha in v1.28, and will be hidden behind a `KUBECTL_INTERACTIVE_DELETE` environment variable.
 
 This [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3895-kubectl-delete-interactivity) and the [associated PR](https://github.com/kubernetes/kubernetes/pull/114530) was authored by [Arda Güçlü](https://github.com/ardaguclu).
 

--- a/_posts/2023-08-20-update.md
+++ b/_posts/2023-08-20-update.md
@@ -1,0 +1,61 @@
+---
+layout: post
+title: Week Ending August 20, 2023
+date: 2023-08-22 22:00:00 -0000
+slug: 2023-08-20-update
+---
+
+## Developer News
+
+We deeply regret to announce the [loss of Kubernetes contributor Kris Nóva](https://hachyderm.io/@jbeda/110922766367332571). A member of our community since the beginning, Kris was known for her contributions to ClusterAPI, Kops, Falco, and many other areas, as well as writing [Cloud Native Intrastructure](https://www.oreilly.com/library/view/cloud-native-infrastructure/9781491984291/). She will be deeply missed. To remember Kris, please donate in her name to [the Nivenly Foundation](https://nivenly.org/) or [Trans Lifeline](https://translifeline.org/).
+
+Get ready to join other contributors at the [Kubernetes Contributor Summit North America](http://k8s.dev/summit) in Chicago.  [Registration](https://cvent.me/qRPey3) is open, as is the [call for sessions](https://forms.gle/htQSHpot9rp1csDz8), including workshops, discussions, and SIG meetings.
+
+Ana Margarita Medina and Jeremy Rickard have been elected to the [Kubernetes Code of Conduct Committee](https://groups.google.com/a/kubernetes.io/g/dev/c/YfyhGdTr3iA).
+
+Steering committee nominations are [still open](https://github.com/kubernetes/community/tree/master/elections/steering/2023#candidacy-process) until August 26th; please get your candidate or self nomination in soon.  And check your [voting status](https://github.com/kubernetes/community/tree/master/elections/steering/2023#voter-exception).
+
+## Release Schedule
+
+**1.28 Is Released!  Yaaay!**
+
+Kubernetes v1.28, "Planternetes", [is now available](https://kubernetes.io/blog/2023/08/15/kubernetes-v1-28-release/).  It has 45 enhancements, including 19 new alpha features, among them: recovery from unexpected node shutdown,  improved CRD validation, increased support for mixed-version clusters, replacement and backoff for Job pods, and complex device container support.  Try out 1.28 today!
+
+[Shadow Applications](https://groups.google.com/a/kubernetes.io/g/dev/c/BANLmyqhfWo) to join the 1.29 Release Team are open.
+
+Patch releases for all supported versions are expected out on the 23rd, including another Go version bump.
+
+## KEP of the Week
+
+
+## Other Merges
+
+* Expose LoadBalancer [IP mode behavior](https://github.com/kubernetes/kubernetes/pull/119937) to Kubernetes API, implementing [KEP 1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding)
+* Scheduler: Straighten out [how Scheduler Permit plugins and unschedulable plugins are handled](https://github.com/kubernetes/kubernetes/pull/119785), [don't bother with preemption](https://github.com/kubernetes/kubernetes/pull/119778) or [calculate Taint tolerations](https://github.com/kubernetes/kubernetes/pull/119399) for unschedulable pods, but don't [skip PostFilter plugins](https://github.com/kubernetes/kubernetes/pull/119769) just because we skipped preFilter ones, treat [volume beta labels](https://github.com/kubernetes/kubernetes/pull/118923) as GA for scheduling, and shrink the Scheduler cache [by excluting managedFields](https://github.com/kubernetes/kubernetes/pull/119556
+* Put the [Pod UID](https://github.com/kubernetes/kubernetes/pull/119971) in the event log
+* Include sidecar resources in [describe node](https://github.com/kubernetes/kubernetes/pull/119509)
+* kubeadm: [push down repository choice](https://github.com/kubernetes/kubernetes/pull/120072), [cert key validation](https://github.com/kubernetes/kubernetes/pull/120064),
+* ValidatingAdmissionPolicy is [v1beta1 API](https://github.com/kubernetes/kubernetes/pull/120018)
+* New metrics: [KMS2 cache filled](https://github.com/kubernetes/kubernetes/pull/119878), [APF inqueue seats](https://github.com/kubernetes/kubernetes/pull/119385), [pod scheduling SLI](https://github.com/kubernetes/kubernetes/pull/119049)
+* Add [Go 1.21 support](https://github.com/kubernetes/kubernetes/pull/119860) for golangci-lint
+* Log aggregated API server [group version changes](https://github.com/kubernetes/kubernetes/pull/119825) and [cache populated](https://github.com/kubernetes/kubernetes/pull/119796) messages only once
+* Estimate [propagation costs](https://github.com/kubernetes/kubernetes/pull/119800) for CEL better
+* Don't let non-LB services [set .status.loadBalancer](https://github.com/kubernetes/kubernetes/pull/119789))
+* [wait.PollUntilContextTimeout](https://github.com/kubernetes/kubernetes/pull/119746) is the new wait.Poll
+* Better [JSONpath parsing](https://github.com/kubernetes/kubernetes/pull/118748) in `kubectl --wait`
+* Stop reusing the same [VolumeResourceRequirements struct](https://github.com/kubernetes/kubernetes/pull/118653) for both containers and PVCs
+* Reuse [gRPC connections](https://github.com/kubernetes/kubernetes/pull/118619) for DRA
+* New audit annotations for [long-lived secrets](https://github.com/kubernetes/kubernetes/pull/118598)
+
+Testing improvements: [kubeadm kubeconfig](https://github.com/kubernetes/kubernetes/pull/119984), [StorageClass](https://github.com/kubernetes/kubernetes/pull/119948), [start.ordinal](https://github.com/kubernetes/kubernetes/pull/119761), [kms2 enablement](https://github.com/kubernetes/kubernetes/pull/119714), [kubeadm proxy](https://github.com/kubernetes/kubernetes/pull/119562), [table0-driven controller tests](https://github.com/kubernetes/kubernetes/pull/119214)
+
+## Promotions
+
+* [kubelet resource metrics to GA](https://github.com/kubernetes/kubernetes/pull/116897)
+
+## Deprecated
+
+* [Purge API tipes](https://github.com/kubernetes/kubernetes/pull/119806) used for removed PodSecurityPolicy feature
+* [Remove expectEqual framework](https://github.com/kubernetes/kubernetes/pull/119494) from e2e testing
+* [Stop using deprecated ioutil](https://github.com/kubernetes/kubernetes/pull/118399) in api-machinery
+* [Drop AvailableResources](https://github.com/kubernetes/kubernetes/pull/117977) from controller context to make controllers less flaky

--- a/_posts/2023-08-20-update.md
+++ b/_posts/2023-08-20-update.md
@@ -27,6 +27,15 @@ Patch releases for all supported versions are expected out on the 23rd, includin
 
 ## KEP of the Week
 
+[KEP-3895: Interactive(-i) flag to kubectl delete for user confirmation](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3895-kubectl-delete-interactivity)
+
+This KEP adds an interactive mode for `kubectl delete` command, which provides users an option to confirm whether or not to delete the resources mentioned. Due to backwards compatibility reasons, directly asking the user for confirmation before deleting is not possible. Hence a new interactive flag (-i) is introduced, which when used would prompt the user to confirm if they really want to delete the resources selected.
+
+When using the proposed interactive flag with `kubectl delete`, the user would be shown the list of resources that would be deleted. The command continues execution if the user confirms by entering `y`. If the user enters `n` or any other character, the command stops execution and returns a message with zero exit code.
+
+This KEP is in alpha in v1.28, and would be hidden behind a `KUBECTL_INTERACTIVE_DELETE` environment variable. The interactive flag can only be used if `KUBECTL_INTERACTIVE_DELETE=true` is exported.
+
+This [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3895-kubectl-delete-interactivity) and the [associated PR](https://github.com/kubernetes/kubernetes/pull/114530) was authored by [Arda Güçlü](https://github.com/ardaguclu).
 
 ## Other Merges
 

--- a/_posts/2023-10-01-update.md
+++ b/_posts/2023-10-01-update.md
@@ -26,6 +26,12 @@ John Belamaric also [clarified that PRR Freeze](https://groups.google.com/a/kube
 
 ## KEP of the Week
 
+### [KEP-3705: Cloud Dual-Stack --node-ip Handling](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3705-cloud-node-ips)
+
+This KEP proposes to add dual-stack `--node-ip` support to kubelet for clusters using a cloud provider. Currently it is only supported by bare metal clusters. This would allow admins of clusters on a cloud provider to override both node IPs on a node in a dual stack cluster. Currently if you pass `--cloud-provider` to kubelet, it expects `--node-ip` to either be unset or a single IP address. This KEP will allow comma separated dual-stack values for `--node-ip` in clusters using non-legacy cloud providers.
+
+This KEP is targeting `beta` milestone in the upcoming v1.29 release is authored by [Dan Winship](https://github.com/danwinship)
+
 ## Other Merges
 
 * KMS2: [use SoftHSM store](https://github.com/kubernetes/kubernetes/pull/120896), make sure [it sends API metrics](https://github.com/kubernetes/kubernetes/pull/120544)


### PR DESCRIPTION
The extra commits are present in this PR since the upstream `20231001` branch is 14 commits behind the upstream `main` branch. Rebasing `kubernetes-sigs/lwkd:20231001` with `kubernetes-sigs/lwkd:main` should resolve it.