### PR TITLE
Add Script Release Crawler

### DIFF
--- a/scripts/release-crawler/README.md
+++ b/scripts/release-crawler/README.md
@@ -1,0 +1,45 @@
+# Release Crawler
+
+The goal of Release-Crawler is to fetch Release notes of configured list of repositories of the previous week. This gives
+an easy overview of updates of relevant projects to put into the LWKD newsletter.
+
+The collected release notes are stored as html and as MD format to be an easy usage.
+
+## Installation & Development
+```
+
+    // install the dependencies
+    go mod download
+
+    // run script
+    go run main.go
+
+    //build go binary
+    go build
+
+```
+
+
+
+
+## Crawled Releases
+
+| Project        |Repository                        |GitHub                         |
+|----------------|-------------------------------|-----------------------------|
+|coredns|coredns           |[CoreDNS](https://github.com/coredns/coredns)|
+|kubernetes-csi|csi-driver-nfs           |[NFS CSI](https://github.com/kubernetes-csi/csi-driver-nfs)|
+|kubernetes-csi|csi-driver-host-path           |[Host Path CSI](https://github.com/kubernetes-csi/csi-driver-host-path)|
+|kubernetes-csi|csi-driver-smb           |[SMB CSI](https://github.com/kubernetes-csi/csi-driver-smb )|
+|kubernetes-csi|csi-driver-vsphere           |[vsphere CSI](https://github.com/kubernetes-csi/csi-driver-vsphere)|
+|containernetworking|cni           |[CNI](https://github.com/containernetworking/cni)|
+|cri-o|cri-o           |[Cri-O](https://github.com/cri-o/cri-o)|
+|cri-o|ocicni           |[Cri-O CNI](https://github.com/cri-o/ocicni)|
+|containerd|containerd           |[ContainerD](https://github.com/containerd/containerd)|
+|containerd|nerdctl           |[nerdctl](https://github.com/containerd/nerdctl)|
+|kubernetes|kops           |[kops](https://github.com/kubernetes/kops)|
+|kubernetes|kubeadm           |[kubeADM](https://github.com/kubernetes/kubeadm)|
+|kubernetes|ngninx-ingress           |[NGINX Ingress](https://github.com/kubernetes/ngninx-ingress )|
+|kubernetes|cluster-api           |[ClusterAPI](https://github.com/kubernetes/cluster-api)|
+|etcd-io|etcd           |[ETCD](https://github.com/etcd-io/etcd)|
+|grpc|grpc           |[GRPC](https://github.com/grpc/grpc)|
+|golang|go           |[Golang](https://github.com/golang/go)|

--- a/scripts/release-crawler/go.mod
+++ b/scripts/release-crawler/go.mod
@@ -1,0 +1,9 @@
+module github.com/example/news-crawler
+
+go 1.20
+
+require github.com/gomarkdown/markdown v0.0.0-20231115200524-a660076da3fd
+
+require github.com/google/go-github/v57 v57.0.0
+
+require github.com/google/go-querystring v1.1.0 // indirect

--- a/scripts/release-crawler/main.go
+++ b/scripts/release-crawler/main.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+"context"
+"fmt"
+"html/template"
+"log"
+"os"
+"time"
+
+"github.com/gomarkdown/markdown"
+
+"github.com/gomarkdown/markdown/html"
+"github.com/gomarkdown/markdown/parser"
+"github.com/google/go-github/v57/github"
+)
+
+var repos map[string][]string = map[string][]string{
+	"coredns": []string{"coredns"},
+	"kubernetes-csi": []string{
+		"csi-driver-nfs",
+		"csi-driver-host-path",
+		"csi-driver-smb",
+		"csi-driver-vsphere",
+	},
+	"containernetworking": []string{"cni"},
+	"cri-o": []string{
+		"cri-o",
+		"ocicni",
+	},
+	"containerd": []string{
+		"containerd",
+		"nerdctl",
+	},
+	"kubernetes": []string{
+		"kops",
+		"kubeadm",
+		"ngninx-ingress",
+		"cluster-api",
+	},
+	"etcd-io": []string{
+		"etcd",
+	},
+	"grpc" : []string{
+		"grpc",
+	},
+	"golang": []string{
+		"go",
+	},
+
+
+}
+
+// mdToHTML converts markdown to HTML
+
+func mdToHTML(md []byte) []byte {
+	// create markdown parser with extensions
+	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
+	p := parser.NewWithExtensions(extensions)
+	doc := p.Parse(md)
+
+	// create HTML renderer with extensions
+	htmlFlags := html.CommonFlags | html.HrefTargetBlank
+	opts := html.RendererOptions{Flags: htmlFlags}
+	renderer := html.NewRenderer(opts)
+
+	return markdown.Render(doc, renderer)
+}
+
+func createHTMLFile(filename string, data map[string]string) error {
+
+	templateContent, err := os.ReadFile("template.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	funcMap := template.FuncMap{
+		"safeHTML": func(str string) template.HTML {
+			return template.HTML(str)
+		},
+	}
+
+	tmpl, err := template.New("template").Funcs(funcMap).Parse(string(templateContent))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// remove File if exists
+	if _, err := os.Stat("release-notes-html/"+filename+ ".html"); err == nil {
+		err = os.Remove("release-notes-html/"+filename+ ".html")
+		if err != nil {
+			return err
+		}
+	}
+	// Create the file and get the file pointer
+	file, err := os.Create("release-notes-html/"+filename + ".html")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Execute the template with the file pointer and data
+	err = tmpl.Execute(file, data)
+
+	//data escaped
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createMDFile(filename string, mdContent string) error {
+
+	// remove File if exists
+	if _, err := os.Stat("release-notes-md/"+filename+ ".md"); err == nil {
+		err = os.Remove("release-notes-md/"+filename+ ".md")
+		if err != nil {
+			return err
+		}
+	}
+	// Create the file and get the file pointer
+	file, err := os.Create("release-notes-md/"+filename+ ".md")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(mdContent)
+
+	return err
+}
+
+// main function
+func main() {
+	ctx := context.Background()
+
+	now := time.Now()
+	client := github.NewClient(nil)
+	oneWeekAgo := now.AddDate(0, 0, -7)
+
+	var mdContent string
+	var htmlContent string
+	htmlContent += "<h1>Latest Releases for " + oneWeekAgo.Format("2006-01-02") + "</h1>"
+	mdContent += "# Latest Releases for " + oneWeekAgo.Format("2006-01-02") + " "
+	weekfile := oneWeekAgo.Format("2006-01-02")
+
+
+	for p, rs := range repos {
+		for _, r := range rs {
+			releases, _, err := client.Repositories.ListReleases(ctx, p, r, &github.ListOptions{
+				PerPage: 5,
+			})
+
+			if err == nil {
+				htmlContent += "<h2>" + p + "/" + r + "</h2> "
+				mdContent += "## " + p + "/" + r
+				for _, release := range releases {
+					if release.GetPublishedAt().After(oneWeekAgo) {
+
+						htmlContent += "<h3>Release notes for " + release.GetName() + "</h3>"
+						htmlContent += "<h4>" + release.GetPublishedAt().Format("2006-01-02") + "</h4>"
+
+						mdContent += "### Release notes for " + release.GetName()
+						mdContent += "#### " + release.GetPublishedAt().Format("2006-01-02")
+
+
+						content := []byte(release.GetBody())
+
+						mdContent += string(content)
+						htmlContent += string(mdToHTML(content))
+						htmlContent += "<br>"
+
+					}
+
+				}
+			} else {
+				fmt.Println(err)
+			}
+
+		}
+	}
+
+	data := make(map[string]string)
+	data["content"] = htmlContent
+	data["title"] = "Whats new in the last week"
+	data["date"] = now.Format("2006-01-02")
+
+	err := createHTMLFile(weekfile, data)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = createMDFile(weekfile, mdContent)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Done")
+}

--- a/scripts/release-crawler/template.html
+++ b/scripts/release-crawler/template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>{{ .title }}</title>
+</head>
+
+<body>
+{{ .content | safeHTML }}
+</body>
+
+</html>


### PR DESCRIPTION
## Fixes #266 


Inital Version of Crawler to get last weeks release notes of relevant projects to get an easy news overview for the creation of the newsletter.
Creates an .md and .html output

Initial Repository list is based on #265 