### PR TITLE
Correct typo from 'kubenetes' to 'kubernetes'

### DIFF
--- a/_posts/2018-12-02-update.md
+++ b/_posts/2018-12-02-update.md
@@ -57,7 +57,7 @@ And finally a shorter entry, a tweak to the scheduler loop to prevent scheduler 
 
 ## Version Updates
 
-* [kubenetes-cni to 0.6.0](https://github.com/kubernetes/kubernetes/pull/71629)
+* [kubernetes-cni to 0.6.0](https://github.com/kubernetes/kubernetes/pull/71629)
 * [conntrack is now a dependancy](https://github.com/kubernetes/kubernetes/pull/71540) of kubelet and kubeadm
 * [node-problem-detector to 0.6.0](https://github.com/kubernetes/kubernetes/pull/71522)
 * [kubernetes.io/uitls to 8e7ff06](https://github.com/kubernetes/kubernetes/pull/71047)


### PR DESCRIPTION
## Description

Correct typo from 'kubenetes' to 'kubernetes'.