### PR TITLE
Change github action to create a PR for related project releases

### DIFF
--- a/.github/workflows/get-releases-weekly.yaml
+++ b/.github/workflows/get-releases-weekly.yaml
@@ -20,11 +20,23 @@
             go-version: 1.21
         - run: go run main.go
         # Commit and push all changed files.
-        - name: GIT Commit Build Artifacts (coverage, dist, devdist, docs)
-          run: |
-            git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
-            git config --global user.email "username@users.noreply.github.com"
-            git add release-notes-html/*
-            git add release-notes-md/*
-            git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
-            git push
+        - name: Get current date
+          id: date
+          run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        - name: Create Pull Request
+          uses: peter-evans/create-pull-request@v5
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            commit-message: Add last weeks releated Project Updates
+            title: 'add: last week related project releases'
+            body: |
+              This PR is auto-generated.
+              It adds the latest releases of the past week ${{ steps.date.outputs.date }} to the repository
+            labels: add, automated pr
+            branch: add/related-projects-${{ steps.date.outputs.date }}
+            add-paths: |
+               scripts/release-crawler/release-notes-html/*.html
+               scripts/release-crawler/release-notes-md/*.md
+            base: main
+            signoff: true
+            delete-branch: true


### PR DESCRIPTION
The PR is created to address the broken action issue.

As per definition, commits of GitHub are not permitted and signed. This is due to the takeover of some repositories in the past. 
The new approach would be to create an automatic PR each week, that can be signed and merged. 

For more details see this [discussion](https://kubernetes.slack.com/archives/C03KT3SUJ20/p1703692862754629?thread_ts=1702633620.747079&cid=C03KT3SUJ20)

For this to work we require the following settings:
For this action to work you must explicitly allow GitHub Actions to create pull requests. This setting can be found in a repository's settings under Actions > General > Workflow permissions.

As reference this example was used: https://github.com/kubernetes-retired/contributor-tweets/blob/main/.github/workflows/main.yml
