### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/get-releases-weekly.yaml
+++ b/.github/workflows/get-releases-weekly.yaml
@@ -22,7 +22,7 @@
         # Commit and push all changed files.
         - name: Get current date
           id: date
-          run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+          run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         - name: Create Pull Request
           uses: peter-evans/create-pull-request@v5
           with:


### PR DESCRIPTION
### Description

Closes #283 

Update `.github/workflows/get-releases-weekly.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
```

**TO-BE**

```yaml
run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
```