### PR TITLE
Add Kubespray to Project Update

### DIFF
--- a/scripts/release-crawler/README.md
+++ b/scripts/release-crawler/README.md
@@ -40,6 +40,7 @@ The collected release notes are stored as html and as MD format to be an easy us
 |kubernetes|kubeadm           |[kubeADM](https://github.com/kubernetes/kubeadm)|
 |kubernetes|ngninx-ingress           |[NGINX Ingress](https://github.com/kubernetes/ngninx-ingress )|
 |kubernetes|cluster-api           |[ClusterAPI](https://github.com/kubernetes/cluster-api)|
+|kubernetes-sigs|kubespray          |[Kubespray](https://github.com/kubernetes-sigs/kubespray)|
 |etcd-io|etcd           |[ETCD](https://github.com/etcd-io/etcd)|
 |grpc|grpc           |[GRPC](https://github.com/grpc/grpc)|
 |golang|go           |[Golang](https://github.com/golang/go)|

--- a/scripts/release-crawler/main.go
+++ b/scripts/release-crawler/main.go
@@ -38,6 +38,9 @@ var repos map[string][]string = map[string][]string{
 		"ngninx-ingress",
 		"cluster-api",
 	},
+	"kubernetes-sigs": []string{
+		"kubespray",
+	},
 	"etcd-io": []string{
 		"etcd",
 	},


### PR DESCRIPTION
Kubespray is an easy to use command line tool for kubernetes deployment in sig-cluster-lifecycle.

How about adding it to the release-crawler for “project update” :-)

Thanks 