### PR TITLE
release-crawler: add Cluster API Provider vSphere

### DIFF
--- a/scripts/release-crawler/README.md
+++ b/scripts/release-crawler/README.md
@@ -40,6 +40,7 @@ The collected release notes are stored as html and as MD format to be an easy us
 |kubernetes|kubeadm           |[kubeADM](https://github.com/kubernetes/kubeadm)|
 |kubernetes|ngninx-ingress           |[NGINX Ingress](https://github.com/kubernetes/ngninx-ingress )|
 |kubernetes|cluster-api           |[ClusterAPI](https://github.com/kubernetes/cluster-api)|
+|kubernetes|cluster-api-provider-vsphere|[Cluster API Provider vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)|
 |kubernetes-sigs|kubespray          |[Kubespray](https://github.com/kubernetes-sigs/kubespray)|
 |etcd-io|etcd           |[ETCD](https://github.com/etcd-io/etcd)|
 |grpc|grpc           |[GRPC](https://github.com/grpc/grpc)|

--- a/scripts/release-crawler/main.go
+++ b/scripts/release-crawler/main.go
@@ -48,6 +48,7 @@ var repos map[string][]string = map[string][]string{
 		"cloud-provider-alibaba-cloud",
 	},
 	"kubernetes-sigs": {
+		"cluster-api-provider-vsphere",
 		"kind",
 		"kubebuilder",
 		"kustomize",


### PR DESCRIPTION
This adds https://github.com/kubernetes-sigs/cluster-api-provider-vsphere to the release crawler :-)

Note: CAPI currently does not work but gets fixed via #432 

xref:

- https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/3187