### PR TITLE
Adds formal subproject leadership to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Editors:
 
 * [Josh Berkus](https://github.com/jberkus)
 * [Sreeram Venkitesh](https://github.com/sreeram-venkitesh)
-
-Tech Lead:
-
 * [Noah Kantrowitz](https://github.com/coderanger)
 
 LWKD has multiple regular contributors, and of course any member of the community is welcome to submit items.  Among our regular contributors in 2024 are:
@@ -41,7 +38,7 @@ You can reach the maintainers of this project at:
 
 ## Logo
 
-* The LWKD logo was designed and donated by [GraphArtgency](https://www.graphartgency.com/). Contact them for community-friendly graphic design!
+* The LWKD logo was designed and donated by **GraphArtgency**.
 
 ### Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,29 @@
 
 [The LWKD repository](https://github.com/lwkd/lwkd.github.io) contains the .md files used to produce the weekly Kubernetes updates called "Last Week in Kubernetes Development", or LWKD.  Contributions by pull request are encouraged and accepted.
 
-Feel free to reach out on [Kubernetes Slack](https://slack.k8s.io), #sig-contribex channel to ask questions. 
+Feel free to reach out on [Kubernetes Slack](https://slack.k8s.io), #sig-contribex channel to ask questions.
+
+## Leads and Contributors
+
+LWKD is a subproject of the Contributor Comms subproject of SIG-ContribEx.  Its leadership is:
+
+Editors:
+
+* [Josh Berkus](https://github.com/jberkus)
+* [Sreeram Venkitesh](https://github.com/sreeram-venkitesh)
+
+Tech Lead:
+
+* [Noah Kantrowitz](https://github.com/coderanger)
+
+LWKD has multiple regular contributors, and of course any member of the community is welcome to submit items.  Among our regular contributors in 2024 are:
+
+* [Aakansha Priya](https://github.com/priyaaakansha)
+* [Mario Fahlandt](https://github.com/mfahlandt)
+* [Faeka Ansari](https://github.com/fykaa)
+* [Satyam Soni](https://github.com/satyampsoni)
+
+A full list of contributors can be found on our [github repository](https://github.com/kubernetes-sigs/lwkd/graphs/contributors)
 
 ## Licensing
 
@@ -16,6 +38,10 @@ You can reach the maintainers of this project at:
 
 - [Slack](https://kubernetes.slack.com/messages/sig-contribex)
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-contribex)
+
+## Logo
+
+* The LWKD logo was designed and donated by [GraphArtgency](https://www.graphartgency.com/). Contact them for community-friendly graphic design!
 
 ### Code of conduct
 

--- a/authors.md
+++ b/authors.md
@@ -1,28 +1,3 @@
 LWKD is a subproject of Kubernetes [SIG Contributor Experience](https://github.com/kubernetes/community/tree/master/sig-contributor-experience).
 
-# Editors of LWKD
-
-* *JMB* [Josh Berkus](https://github.com/jberkus)
-* *NK* [Noah Kantrowitz](https://github.com/coderanger)
-
-# List of Additional Contributors To LWKD
-
-## 2023
-
-* *SV* [Sreeram Venkitesh](https://github.com/sreeram-venkitesh)
-* *FA* [Faēka Ansari](https://github.com/fykaa)
-* *MF* [Mario Fahlandt](https://github.com/mfahlandt)
-* *SS* [Satyam Soni](https://github.com/satyampsoni)
-
-## 2022
-
-* *AT* [Avinesh Tripathi](https://github.com/AvineshTripathi)
-
-## 2019
-
-* *FD* [Fabian Deutch](https://github.com/fabiand)
-* *SC* [Scott Collier](https://github.com/scollier)
-
-# Logo
-
-* The LWKD logo was designed and donated by [GraphArtgency](https://www.graphartgency.com/). Contact them for community-friendly graphic design!
+See the [README](README.md) for editorial and contributor information.

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 LWKD is a weekly newsletter summarizing code activity in the Kubernetes project: merges, PRs, deprecations, version updates, release schedules, and community meetings.  It does not cover events or news in the Kubernetes ecosystem, as our sister publication [KubeWeekly](https://www.cncf.io/kubeweekly/) does a great job of handling those.
 
-LWKD is the product of [contributors from the Kubernetes Project's SIG-Contributor Experience](/authors).  If you're interested in helping with LWKD, see our [README](https://github.com/lwkd/lwkd.github.io).  You can also contact us at lwkd@kubernetes.io.
+LWKD is the product of [contributors from the Kubernetes Project's SIG-Contributor Experience](https://github.com/lwkd/lwkd.github.io).  If you're interested in helping with LWKD, see our [README](https://github.com/lwkd/lwkd.github.io).  You can also contact us at lwkd@kubernetes.io.
 
 [Subscribe](https://buttondown.email/LastWeekInKubernetes) to receive LWKD by email, or [follow us on Twitter](https://twitter.com/LWKDNews) or on our [RSS feed](/feed.xml)
 


### PR DESCRIPTION
Adds Sreeram as subsubproject lead.

Tombstones authors file.

/assign @kaslin 