### PR TITLE
featured PR: Fix `PodTopologySpread` matching pods counts for constraints with the same topologyKey

### DIFF
--- a/_posts/2025-01-05-update.md
+++ b/_posts/2025-01-05-update.md
@@ -17,6 +17,13 @@ While we're in the pre-release cycle period, the Release Team is [still looking 
 
 ## Featured PRs
 
+[129119: Fix PodTopologySpread matching pods counts for constraints with the same topologyKey](https://github.com/kubernetes/kubernetes/pull/129119)
+
+This PR addresses a bug in the Kubernetes scheduler where constraints sharing the same `topologyKey` could incorrectly
+overwrite each other’s results. By updating the `PodTopologySpread` plugin to index data structures by constraint,
+it isolates each constraint's results. Additionally, replacing a map with a slice in the PreFilter stage significantly
+improves scheduling throughput for pods with topology spreading, boosting performance by up to 25% on large clusters.
+This change ensures more accurate scheduling and better resource distribution across nodes.
 
 ## KEP of the Week
 


### PR DESCRIPTION
For Article 20250105