### PR TITLE
Fix KEP-3015 description in 2025-06-08-update.md

### DIFF
--- a/_posts/2025-06-08-update.md
+++ b/_posts/2025-06-08-update.md
@@ -31,7 +31,7 @@ This PR allows users to set custom labels on LeaseLock resources when a new hold
 
 [KEP 3015: PreferSameZone and PreferSameNode Traffic Distribution](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3015-prefer-same-node)
 
-This enhancement deprecated the `PreferClose` Pod Topology Spread Constraints type and replaced it with `PreferSameZone` as a new name for the old behaviour. The KEP also added a new value `PreferSameNode`, which indicates that traffic for a service should preferentially be routed to endpoints on the same node as the client. This KEP made traffic distribution less ambiguous and delivers traffic to a local endpoint when possible. If the local endpoint is unavailable, the traffic is routed to a remote endpoint.
+This enhancement deprecated the `PreferClose` Traffic Distribution value and replaced it with `PreferSameZone` as a new name for the old behaviour. The KEP also added a new value `PreferSameNode`, which indicates that traffic for a service should preferentially be routed to endpoints on the same node as the client. This KEP made traffic distribution less ambiguous and delivers traffic to a local endpoint when possible. If the local endpoint is unavailable, the traffic is routed to a remote endpoint.
 
 This KEP is tracked for beta in v1.34.
 


### PR DESCRIPTION
The description of KEP-3015 refers to "Pod Topology Spread Constraints" but it should say "Traffic Distribution". (Pod Topology Spread Constraints are discussed at one point, but that's not what the KEP is about.)